### PR TITLE
issue-#3435-replace-asList-image-pull-policy-enricher-test

### DIFF
--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.kit.config.service.openshift;
 
 import io.fabric8.openshift.client.OpenShiftClient;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.build.service.docker.ArchiveService;
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
@@ -181,7 +182,7 @@ class OpenShiftBuildServiceTest {
         .extracting(ImageConfiguration::getBuild)
         .extracting(BuildConfiguration::getAssembly)
         .extracting(AssemblyConfiguration::getLayers)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
         .hasSize(2);
   }
 
@@ -202,7 +203,7 @@ class OpenShiftBuildServiceTest {
         .extracting(ImageConfiguration::getBuild)
         .extracting(BuildConfiguration::getAssembly)
         .extracting(AssemblyConfiguration::getLayers)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
         .hasSize(1);
   }
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricherTest.java
@@ -223,8 +223,8 @@ class ImagePullPolicyEnricherTest {
         .extracting(DaemonSetSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
-        .singleElement(InstanceOfAssertFactories.type(Container.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
+        .singleElement()
         .extracting(Container::getImagePullPolicy)
         .isEqualTo(expectedImagePullPolicy);
   }
@@ -236,8 +236,8 @@ class ImagePullPolicyEnricherTest {
         .extracting(DeploymentSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
-        .singleElement(InstanceOfAssertFactories.type(Container.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
+        .singleElement()
         .extracting(Container::getImagePullPolicy)
         .isEqualTo(expectedImagePullPolicy);
   }
@@ -270,8 +270,8 @@ class ImagePullPolicyEnricherTest {
         .extracting(JobSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
-        .singleElement(InstanceOfAssertFactories.type(Container.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
+        .singleElement()
         .extracting(Container::getImagePullPolicy)
         .isEqualTo(expectedImagePullPolicy);
   }
@@ -283,8 +283,8 @@ class ImagePullPolicyEnricherTest {
         .extracting(ReplicaSetSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
-        .singleElement(InstanceOfAssertFactories.type(Container.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
+        .singleElement()
         .extracting(Container::getImagePullPolicy)
         .isEqualTo(expectedImagePullPolicy);
   }
@@ -296,8 +296,8 @@ class ImagePullPolicyEnricherTest {
         .extracting(ReplicationControllerSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
-        .singleElement(InstanceOfAssertFactories.type(Container.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
+        .singleElement()
         .extracting(Container::getImagePullPolicy)
         .isEqualTo(expectedImagePullPolicy);
   }
@@ -309,8 +309,8 @@ class ImagePullPolicyEnricherTest {
         .extracting(StatefulSetSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
-        .singleElement(InstanceOfAssertFactories.type(Container.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
+        .singleElement()
         .extracting(Container::getImagePullPolicy)
         .isEqualTo(expectedImagePullPolicy);
 


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Replaced AsList()  Deprected  Methods with AsertJ's asInstanceOf(InstanceOfAssertFactories.list(Type.class))
Fixes #3435


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
